### PR TITLE
Make NABU use Internet adapter by default

### DIFF
--- a/src/devices/bus/nabu/adapter.h
+++ b/src/devices/bus/nabu/adapter.h
@@ -28,7 +28,7 @@ public:
 public:
 	std::error_condition load(const char * local_path, uint32_t segment_id);
 	const pak& operator[](const int index) const;
-	uint32_t size() { return pak_list.size(); }
+	uint32_t size() const { return pak_list.size(); }
 private:
 	static constexpr uint16_t crc_table[256] = {
 		0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7, 0x8108, 0x9129, 0xa14a, 0xb16b,


### PR DESCRIPTION
Change defaults to make nabupc driver work out of the box with the Internet adapter software via TCP.